### PR TITLE
Remove a free call that causes an use-after-free error

### DIFF
--- a/libParseURL.c
+++ b/libParseURL.c
@@ -50,8 +50,6 @@ char *init_response_parse(char* input)
 
 	output[j] ='\0';
 
-	free(output);
-
 	return output;                                                     
 }
 

--- a/test.c
+++ b/test.c
@@ -23,6 +23,7 @@ int main()
     p=init_response_parse(p);
 
     char *last = p;
+    char *allocated = p;
     puts(p);
 
     while(!result )
@@ -49,6 +50,6 @@ int main()
 		    result=1;	
                     break;
 	  }
-
+    free(allocated);
     return 0;
 }


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).